### PR TITLE
Update NuGet push command to include API key in workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -72,5 +72,5 @@ jobs:
       run: |
         SOURCE_ROOT=${SOURCE_ROOT:-"src"}
         for file in "$SOURCE_ROOT"/**/bin/Release/*.nupkg; do
-          dotnet nuget push "$file" --source github --skip-duplicate
+          dotnet nuget push "$file" --source github --skip-duplicate --api-key ${{ secrets.GITHUB_TOKEN }}
         done


### PR DESCRIPTION
Added the `--api-key` parameter with GitHub token to the NuGet push command in the .NET GitHub Actions workflow. This ensures proper authentication when publishing packages. The change resolves potential issues with missing API key credentials.