### PR TITLE
Fix: Run .NET workflow on all branches and tags

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,7 +5,11 @@ name: .NET
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "**" ]
+    branches-ignore:
+      - 'main'
+    tags:
+      - "*"
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,8 +6,6 @@ name: .NET
 on:
   push:
     branches: [ "**" ]
-    branches-ignore:
-      - 'main'
     tags:
       - "*"
   pull_request:


### PR DESCRIPTION
Overview
This change modifies the .NET workflow to run on all branches and tags, instead of just the main branch. This allows for automated testing and deployment of code from any branch or tag.